### PR TITLE
Bump jackson-databind to 2.21.4 (CVE-2026-54513, CVE-2026-54512)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "com.thesamet.scalapb"               %% "scalapb-runtime"                         % scalapb.compiler.Version.scalapbVersion % "protobuf",
   "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.11" % "2.9.6-0"                               % "protobuf",
   "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.11" % "2.9.6-0",
-  "com.fasterxml.jackson.core"         % "jackson-databind"       % "2.14.3"
+  "com.fasterxml.jackson.core"         % "jackson-databind"       % "2.21.4"
 
 )
 


### PR DESCRIPTION
## Summary

Bumps `jackson-databind` from 2.14.3 to 2.21.4 to patch two PolymorphicTypeValidator bypass CVEs:

- **CVE-2026-54513** — `BasicPolymorphicTypeValidator.allowIfSubTypeIsArray()` allowlist bypass via array component types ([advisory](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-rmj7-2vxq-3g9f)). CVSS 8.1.
- **CVE-2026-54512** — `DatabindContext._resolveAndValidateGeneric()` validates only the raw container class, allowing a denied class to be smuggled past a PTV allow-list as a generic type argument (e.g. `ArrayList<Gadget>`).

Both affect 2.10.0 ≤ v < 2.18.8 / 2.21.4 / 3.1.4. The 2.4.0 release of this repo bundles jackson-databind 2.14.3 in the assembly jar, so consumers using the published fat jar as a Conduktor plugin are flagged by Trivy/Grype.

Context: this fixture jar is consumed as a test resource in `conduktor/console-plus` (`modules/consumer/src/test/resources/plugins/`), where scanners pick up the shaded jackson copy. The runtime classpath there already uses 2.21.4 — this PR aligns the example/plugin jar with it.

## Test plan

- [ ] CI passes (`sbt clean test publish` in publish.yml only runs on release; the test workflow runs on PR)
- [ ] After merge, cut a 2.4.1 release to publish a fresh fat jar to GitHub Packages