### PR TITLE
Attach assembly fat jar to GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - uses: coursier/cache-action@v6
@@ -18,7 +21,15 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: Publish package
-        run: sbt clean test publish
+        run: sbt clean test publish assembly
         env:
           CREATED_TAG: ${{ steps.vars.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach fat jar to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          fat_jar="my_custom_deserializers_2.13-${TAG}.jar"
+          cp target/scala-2.13/plugins.jar "${fat_jar}"
+          gh release upload "${TAG}" "${fat_jar}" --clobber


### PR DESCRIPTION
## Summary

Updates `publish.yml` to run `sbt assembly` alongside `publish`, and upload the resulting fat jar (`plugins.jar`) as a release asset named `my_custom_deserializers_2.13-<tag>.jar`.

## Why

`sbt publish` uploads the *thin* jar to GitHub Packages (Maven), which is fine for Maven consumers. But the documented usage of this repo — and the way `conduktor/console-plus` consumes it as a Conduktor plugin test fixture (`modules/consumer/src/test/resources/plugins/`) — needs the *fat* assembly jar with shaded dependencies. The README itself points users at the GitHub Packages page to "download the latest jar," but the assembly jar isn't published there.

Without this, after #114 lands on 2.4.1 the fat jar still ships the old jackson, and downstream scanner findings (CVE-2026-54513, CVE-2026-54512) remain.

## Changes

- Add `permissions: contents: write, packages: write` to the publish job so `gh release upload` can attach assets.
- Run `sbt clean test publish assembly` (adds the assembly step).
- New step: copy `target/scala-2.13/plugins.jar` to `my_custom_deserializers_2.13-<tag>.jar` and upload to the release with `gh release upload --clobber`.

## Test plan

- [ ] CI passes on this PR (test workflow only; publish.yml fires on release)
- [ ] After merge, cut a new release (2.4.2). Verify the release page has `my_custom_deserializers_2.13-2.4.2.jar` attached and that `unzip -l` shows shaded `jackson-databind-2.21.4`.